### PR TITLE
Fix DataFrame.sample with frac parameter

### DIFF
--- a/lib/polars/data_frame.rb
+++ b/lib/polars/data_frame.rb
@@ -4234,7 +4234,7 @@ module Polars
       if n.nil? && !frac.nil?
         frac = Series.new("frac", [frac]) unless frac.is_a?(Series)
 
-        _from_rbdf(
+        return _from_rbdf(
           _df.sample_frac(frac._s, with_replacement, shuffle, seed)
         )
       end


### PR DESCRIPTION
The method is missing an early return, so it always samples one row if `frac` is passed.

```ruby
3.3.1 :168 > df.size
 => 3000
3.3.1 :169 > df.sample(frac: 0.5)
 =>
shape: (1, 2)
┌─────┬─────┐
│ a   ┆ b   │
│ --- ┆ --- │
│ i64 ┆ str │
╞═════╪═════╡
│ 1   ┆ one │
└─────┴─────┘
```