### PR TITLE
Update set_sorted method docs to match Python

### DIFF
--- a/lib/polars/data_frame.rb
+++ b/lib/polars/data_frame.rb
@@ -5101,12 +5101,16 @@ module Polars
       lazy.merge_sorted(other.lazy, key).collect(_eager: true)
     end
 
-    # Indicate that one or multiple columns are sorted.
+    # Flag a column as sorted.
+    #
+    # This can speed up future operations.
+    #
+    # Warning: This can lead to incorrect results if the data is NOT sorted! Use with care!
     #
     # @param column [Object]
-    #   Columns that are sorted
+    #   Column that is sorted.
     # @param descending [Boolean]
-    #   Whether the columns are sorted in descending order.
+    #   Whether the column is sorted in descending order.
     #
     # @return [DataFrame]
     def set_sorted(

--- a/lib/polars/lazy_frame.rb
+++ b/lib/polars/lazy_frame.rb
@@ -3347,12 +3347,16 @@ module Polars
       _from_rbldf(_ldf.merge_sorted(other._ldf, key))
     end
 
-    # Indicate that one or multiple columns are sorted.
+    # Flag a column as sorted.
+    #
+    # This can speed up future operations.
+    #
+    # Warning: This can lead to incorrect results if the data is NOT sorted! Use with care!
     #
     # @param column [Object]
-    #   Columns that are sorted
+    #   Column that is sorted.
     # @param descending [Boolean]
-    #   Whether the columns are sorted in descending order.
+    #   Whether the column is sorted in descending order.
     #
     # @return [LazyFrame]
     def set_sorted(


### PR DESCRIPTION
Main fix: plural language which confused me into thinking that the `column` argument supports multiple columns.

Matches the docs here now: https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.set_sorted.html#polars.DataFrame.set_sorted

Ruby docs site: https://www.rubydoc.info/gems/polars-df/Polars/DataFrame#set_sorted-instance_method