### PR TITLE
Add support for horizontal concatenation of LazyFrames

### DIFF
--- a/ext/polars/src/functions/lazy.rs
+++ b/ext/polars/src/functions/lazy.rs
@@ -205,6 +205,21 @@ pub fn concat_lf_diagonal(
     Ok(lf.into())
 }
 
+pub fn concat_lf_horizontal(lfs: RArray, parallel: bool) -> RbResult<RbLazyFrame> {
+    let iter = lfs.into_iter();
+
+    let lfs = iter.map(get_lf).collect::<RbResult<Vec<_>>>()?;
+
+    let args = UnionArgs {
+        rechunk: false, // No need to rechunk with horizontal concatenation
+        parallel,
+        to_supertypes: false,
+        ..Default::default()
+    };
+    let lf = dsl::functions::concat_lf_horizontal(lfs, args).map_err(RbPolarsErr::from)?;
+    Ok(lf.into())
+}
+
 pub fn dtype_cols(dtypes: RArray) -> RbResult<RbExpr> {
     let dtypes = dtypes
         .into_iter()

--- a/ext/polars/src/lib.rs
+++ b/ext/polars/src/lib.rs
@@ -614,6 +614,10 @@ fn init(ruby: &Ruby) -> RbResult<()> {
         "concat_lf_diagonal",
         function!(functions::lazy::concat_lf_diagonal, 4),
     )?;
+    class.define_singleton_method(
+        "concat_lf_horizontal",
+        function!(functions::lazy::concat_lf_horizontal, 2),
+    )?;
     class.define_singleton_method("concat_df", function!(functions::eager::concat_df, 1))?;
     class.define_singleton_method("concat_lf", function!(functions::lazy::concat_lf, 4))?;
     class.define_singleton_method(

--- a/lib/polars/functions/eager.rb
+++ b/lib/polars/functions/eager.rb
@@ -7,7 +7,6 @@ module Polars
     # @param rechunk [Boolean]
     #   Make sure that all data is in contiguous memory.
     # @param how ["vertical", "vertical_relaxed", "diagonal", "horizontal"]
-    #   LazyFrames do not support the `horizontal` strategy.
     #
     #   - Vertical: applies multiple `vstack` operations.
     #   - Diagonal: finds a union between the column schemas and fills missing column values with null.
@@ -55,8 +54,10 @@ module Polars
           return Utils.wrap_ldf(Plr.concat_lf(items, rechunk, parallel, true))
         elsif how == "diagonal"
           return Utils.wrap_ldf(Plr.concat_lf_diagonal(items, rechunk, parallel, false))
+        elsif how == "horizontal"
+          return Utils.wrap_ldf(Plr.concat_lf_horizontal(items, parallel))
         else
-          raise ArgumentError, "Lazy only allows 'vertical', 'vertical_relaxed', and 'diagonal' concat strategy."
+          raise ArgumentError, "Lazy only allows 'vertical', 'vertical_relaxed', 'horizontal', and 'diagonal' concat strategy."
         end
       elsif first.is_a?(Series)
         # TODO

--- a/test/lazy_frame_test.rb
+++ b/test/lazy_frame_test.rb
@@ -78,4 +78,12 @@ class LazyFrameTest < Minitest::Test
     Polars.concat([df1, df2], how: "vertical_relaxed")
     Polars.concat([df1, df2], how: "diagonal")
   end
+
+  def test_concat_horizontal
+    df1 = Polars::LazyFrame.new({"a" => [1, 2]})
+    df2 = Polars::LazyFrame.new({"b" => [3, 4]})
+    df = Polars.concat([df1, df2], how: "horizontal").collect
+    expected = Polars::DataFrame.new({"a" => [1, 2], "b" => [3, 4]})
+    assert_frame expected, df
+  end
 end


### PR DESCRIPTION
This PR adds support for `Polars.concat([lazy_frame_1, lazy_frame_2], how: "horizontal")`. This mode of concatenation used to not be supported for LazyFrames.

Code change is the ruby equivalent of the changes to `py-polars` done in this PR: https://github.com/pola-rs/polars/pull/13139