### PR TITLE
Always try Numo::Bit.cast(to_a) for boolean

### DIFF
--- a/lib/polars/series.rb
+++ b/lib/polars/series.rb
@@ -2554,10 +2554,11 @@ module Polars
     #   # Numo::Int64#shape=[3]
     #   # [1, 2, 3]
     def to_numo
+      return Numo::Bit.cast(to_a) if is_boolean
+      return Numo::RObject.cast(to_a) if is_datelike
+
       if !has_validity
-        if is_datelike
-          Numo::RObject.cast(to_a)
-        elsif is_numeric
+        if is_numeric
           # TODO make more efficient
           {
             UInt8 => Numo::UInt8,
@@ -2569,15 +2570,11 @@ module Polars
             Int32 => Numo::Int32,
             Int64 => Numo::Int64,
             Float32 => Numo::SFloat,
-            Float64 => Numo::DFloat
+            Float64 => Numo::DFloat,
           }.fetch(dtype.class).cast(to_a)
-        elsif is_boolean
-          Numo::Bit.cast(to_a)
         else
           _s.to_numo
         end
-      elsif is_datelike
-        Numo::RObject.cast(to_a)
       else
         _s.to_numo
       end


### PR DESCRIPTION
Hey Andrew!

I noticed today that when calling `to_numo` on Boolean columns that have nulls, we get:

```ruby
=> #<Polars::ComputeError: 'to_numo' not supported for dtype: Boolean>
```

Because we're short-circuiting the `Numo::Bit.cast` logic and calling `to_numo` on the `RbSeries`

I'm not sure this is the best solution (I would probably prefer to receive an error about casting a column containing nulls), but I thought this solution fit better with your current implementation. What do you think? 