### PR TITLE
Fix drop_nulls not passing a Selector type as subset argument

### DIFF
--- a/lib/polars/data_frame.rb
+++ b/lib/polars/data_frame.rb
@@ -1848,10 +1848,13 @@ module Polars
       _from_rbdf(_df.tail(n))
     end
 
-    # Return a new DataFrame where the null values are dropped.
+    # Drop all rows that contain one or more null values.
+    #
+    # The original order of the remaining rows is preserved.
     #
     # @param subset [Object]
-    #   Subset of column(s) on which `drop_nulls` will be applied.
+    #   Column name(s) for which null values are considered.
+    #   If set to `nil` (default), use all columns.
     #
     # @return [DataFrame]
     #
@@ -1860,20 +1863,31 @@ module Polars
     #     {
     #       "foo" => [1, 2, 3],
     #       "bar" => [6, nil, 8],
-    #       "ham" => ["a", "b", "c"]
+    #       "ham" => ["a", "b", nil],
     #     }
     #   )
     #   df.drop_nulls
     #   # =>
-    #   # shape: (2, 3)
+    #   # shape: (1, 3)
     #   # ┌─────┬─────┬─────┐
     #   # │ foo ┆ bar ┆ ham │
     #   # │ --- ┆ --- ┆ --- │
     #   # │ i64 ┆ i64 ┆ str │
     #   # ╞═════╪═════╪═════╡
     #   # │ 1   ┆ 6   ┆ a   │
-    #   # │ 3   ┆ 8   ┆ c   │
     #   # └─────┴─────┴─────┘
+    # @example
+    #   df.drop_nulls(subset: Polars.cs.integer)
+    #   # =>
+    #   # shape: (2, 3)
+    #   # ┌─────┬─────┬──────┐
+    #   # │ foo ┆ bar ┆ ham  │
+    #   # │ --- ┆ --- ┆ ---  │
+    #   # │ i64 ┆ i64 ┆ str  │
+    #   # ╞═════╪═════╪══════╡
+    #   # │ 1   ┆ 6   ┆ a    │
+    #   # │ 3   ┆ 8   ┆ null │
+    #   # └─────┴─────┴──────┘
     def drop_nulls(subset: nil)
       lazy.drop_nulls(subset: subset).collect(_eager: true)
     end

--- a/lib/polars/lazy_frame.rb
+++ b/lib/polars/lazy_frame.rb
@@ -3333,11 +3333,31 @@ module Polars
     #   # │ 1   ┆ 6   ┆ a   │
     #   # │ 3   ┆ 8   ┆ c   │
     #   # └─────┴─────┴─────┘
+    # @example
+    #   df = Polars::DataFrame.new(
+    #     {
+    #       "foo" => [1, 2, nil],
+    #       "bar" => [6, nil, 8],
+    #       "ham" => [nil, "b", "c"]
+    #     }
+    #   )
+    #   df.lazy.drop_nulls(subset: "bar").collect
+    #   # =>
+    #   # shape: (2, 3)
+    #   # ┌──────┬─────┬──────┐
+    #   # │ foo  ┆ bar ┆ ham  │
+    #   # │ ---  ┆ --- ┆ ---  │
+    #   # │ i64  ┆ i64 ┆ str  │
+    #   # ╞══════╪═════╪══════╡
+    #   # │ 1    ┆ 6   ┆ null │
+    #   # │ null ┆ 8   ┆ c    │
+    #   # └──────┴─────┴──────┘
     def drop_nulls(subset: nil)
-      if !subset.nil? && !subset.is_a?(::Array)
-        subset = [subset]
+      selector_subset = nil
+      if !subset.nil?
+        selector_subset = Utils.parse_list_into_selector(subset)._rbselector
       end
-      _from_rbldf(_ldf.drop_nulls(subset))
+      _from_rbldf(_ldf.drop_nulls(selector_subset))
     end
 
     # Unpivot a DataFrame from wide to long format.

--- a/lib/polars/lazy_frame.rb
+++ b/lib/polars/lazy_frame.rb
@@ -3307,51 +3307,46 @@ module Polars
       _from_rbldf(_ldf.unique(maintain_order, selector_subset, keep))
     end
 
-    # Drop rows with null values from this LazyFrame.
+    # Drop all rows that contain one or more null values.
+    #
+    # The original order of the remaining rows is preserved.
     #
     # @param subset [Object]
-    #   Subset of column(s) on which `drop_nulls` will be applied.
+    #   Column name(s) for which null values are considered.
+    #   If set to `nil` (default), use all columns.
     #
     # @return [LazyFrame]
     #
     # @example
-    #   df = Polars::DataFrame.new(
+    #   lf = Polars::LazyFrame.new(
     #     {
-    #       "foo" => [1, 2, 3],
-    #       "bar" => [6, nil, 8],
-    #       "ham" => ["a", "b", "c"]
+    #       "foo": [1, 2, 3],
+    #       "bar": [6, nil, 8],
+    #       "ham": ["a", "b", nil],
     #     }
     #   )
-    #   df.lazy.drop_nulls.collect
+    #   lf.drop_nulls.collect
     #   # =>
-    #   # shape: (2, 3)
+    #   # shape: (1, 3)
     #   # ┌─────┬─────┬─────┐
     #   # │ foo ┆ bar ┆ ham │
     #   # │ --- ┆ --- ┆ --- │
     #   # │ i64 ┆ i64 ┆ str │
     #   # ╞═════╪═════╪═════╡
     #   # │ 1   ┆ 6   ┆ a   │
-    #   # │ 3   ┆ 8   ┆ c   │
     #   # └─────┴─────┴─────┘
     # @example
-    #   df = Polars::DataFrame.new(
-    #     {
-    #       "foo" => [1, 2, nil],
-    #       "bar" => [6, nil, 8],
-    #       "ham" => [nil, "b", "c"]
-    #     }
-    #   )
-    #   df.lazy.drop_nulls(subset: "bar").collect
+    #   lf.drop_nulls(subset: Polars.cs.integer).collect
     #   # =>
     #   # shape: (2, 3)
-    #   # ┌──────┬─────┬──────┐
-    #   # │ foo  ┆ bar ┆ ham  │
-    #   # │ ---  ┆ --- ┆ ---  │
-    #   # │ i64  ┆ i64 ┆ str  │
-    #   # ╞══════╪═════╪══════╡
-    #   # │ 1    ┆ 6   ┆ null │
-    #   # │ null ┆ 8   ┆ c    │
-    #   # └──────┴─────┴──────┘
+    #   # ┌─────┬─────┬──────┐
+    #   # │ foo ┆ bar ┆ ham  │
+    #   # │ --- ┆ --- ┆ ---  │
+    #   # │ i64 ┆ i64 ┆ str  │
+    #   # ╞═════╪═════╪══════╡
+    #   # │ 1   ┆ 6   ┆ a    │
+    #   # │ 3   ┆ 8   ┆ null │
+    #   # └─────┴─────┴──────┘
     def drop_nulls(subset: nil)
       selector_subset = nil
       if !subset.nil?


### PR DESCRIPTION
The latest release (0.21.0) has a bug that breaks `DataFrame#drop_nulls` when used with a `subset` argument:

```rb
dataframe.drop_nulls(subset: "a")
# => TypeError:
#       no implicit conversion of Array into Polars::RbSelector
```

This comes from the following change in type signature in polars:
https://github.com/pola-rs/polars/commit/8a961cd97918e61fa2f3183c7341df224db18d62#diff-744a743b5337b77c8e26e0efabdfe8410bfd77e3d1e55ffa54eb0f29cc51e33bR1904

So we just need to apply the same change that was done in py-polars here:
https://github.com/pola-rs/polars/commit/8a961cd97918e61fa2f3183c7341df224db18d62#diff-6f7ee6a0f7f99cb158f4d68d883a118b9fab6175602e8696739d900c8b0d864fR7399