### PR TITLE
Add drop_nans method to DataFrame and LazyFrame

### DIFF
--- a/ext/polars/src/lazyframe/general.rs
+++ b/ext/polars/src/lazyframe/general.rs
@@ -816,6 +816,14 @@ impl RbLazyFrame {
         .into())
     }
 
+    pub fn drop_nans(&self, subset: Option<&RbSelector>) -> Self {
+        self.ldf
+            .borrow()
+            .clone()
+            .drop_nans(subset.map(|e| e.inner.clone()))
+            .into()
+    }
+
     pub fn drop_nulls(&self, subset: Option<&RbSelector>) -> Self {
         self.ldf
             .borrow()

--- a/ext/polars/src/lib.rs
+++ b/ext/polars/src/lib.rs
@@ -781,6 +781,7 @@ fn init(ruby: &Ruby) -> RbResult<()> {
     class.define_method("explode", method!(RbLazyFrame::explode, 1))?;
     class.define_method("null_count", method!(RbLazyFrame::null_count, 0))?;
     class.define_method("unique", method!(RbLazyFrame::unique, 3))?;
+    class.define_method("drop_nans", method!(RbLazyFrame::drop_nans, 1))?;
     class.define_method("drop_nulls", method!(RbLazyFrame::drop_nulls, 1))?;
     class.define_method("slice", method!(RbLazyFrame::slice, 2))?;
     class.define_method("tail", method!(RbLazyFrame::tail, 1))?;

--- a/lib/polars/data_frame.rb
+++ b/lib/polars/data_frame.rb
@@ -1848,37 +1848,52 @@ module Polars
       _from_rbdf(_df.tail(n))
     end
 
-    # Return a new DataFrame where the NaN values are dropped.
+    # Drop all rows that contain one or more NaN values.
+    #
+    # The original order of the remaining rows is preserved.
     #
     # @param subset [Object]
-    #   Subset of column(s) on which `drop_nans` will be applied.
+    #   Column name(s) for which NaN values are considered; if set to `nil`
+    #   (default), use all columns (note that only floating-point columns
+    #   can contain NaNs).
     #
     # @return [DataFrame]
     #
     # @example
     #   df = Polars::DataFrame.new(
     #     {
-    #       "foo" => [1, 2, 3],
-    #       "bar" => [6, Float::NAN, 8],
-    #       "ham" => ["a", "b", "c"]
+    #       "foo" => [-20.5, Float::NAN, 80.0],
+    #       "bar" => [Float::NAN, 110.0, 25.5],
+    #       "ham" => ["xxx", "yyy", nil],
     #     }
     #   )
     #   df.drop_nans
     #   # =>
+    #   # shape: (1, 3)
+    #   # ┌──────┬──────┬──────┐
+    #   # │ foo  ┆ bar  ┆ ham  │
+    #   # │ ---  ┆ ---  ┆ ---  │
+    #   # │ f64  ┆ f64  ┆ str  │
+    #   # ╞══════╪══════╪══════╡
+    #   # │ 80.0 ┆ 25.5 ┆ null │
+    #   # └──────┴──────┴──────┘
+    # @example
+    #   df.drop_nans(subset: ["bar"])
+    #   # =>
     #   # shape: (2, 3)
-    #   # ┌─────┬─────┬─────┐
-    #   # │ foo ┆ bar ┆ ham │
-    #   # │ --- ┆ --- ┆ --- │
-    #   # │ i64 ┆ f64 ┆ str │
-    #   # ╞═════╪═════╪═════╡
-    #   # │ 1   ┆ 6.0 ┆ a   │
-    #   # │ 3   ┆ 8.0 ┆ c   │
-    #   # └─────┴─────┴─────┘
+    #   # ┌──────┬───────┬──────┐
+    #   # │ foo  ┆ bar   ┆ ham  │
+    #   # │ ---  ┆ ---   ┆ ---  │
+    #   # │ f64  ┆ f64   ┆ str  │
+    #   # ╞══════╪═══════╪══════╡
+    #   # │ NaN  ┆ 110.0 ┆ yyy  │
+    #   # │ 80.0 ┆ 25.5  ┆ null │
+    #   # └──────┴───────┴──────┘
     def drop_nans(subset: nil)
       lazy.drop_nans(subset: subset).collect(_eager: true)
     end
 
-    # Return a new DataFrame where the null values are dropped.
+    # Drop all rows that contain one or more null values.
     #
     # The original order of the remaining rows is preserved.
     #

--- a/lib/polars/data_frame.rb
+++ b/lib/polars/data_frame.rb
@@ -1848,7 +1848,37 @@ module Polars
       _from_rbdf(_df.tail(n))
     end
 
-    # Drop all rows that contain one or more null values.
+    # Return a new DataFrame where the NaN values are dropped.
+    #
+    # @param subset [Object]
+    #   Subset of column(s) on which `drop_nans` will be applied.
+    #
+    # @return [DataFrame]
+    #
+    # @example
+    #   df = Polars::DataFrame.new(
+    #     {
+    #       "foo" => [1, 2, 3],
+    #       "bar" => [6, Float::NAN, 8],
+    #       "ham" => ["a", "b", "c"]
+    #     }
+    #   )
+    #   df.drop_nans
+    #   # =>
+    #   # shape: (2, 3)
+    #   # ┌─────┬─────┬─────┐
+    #   # │ foo ┆ bar ┆ ham │
+    #   # │ --- ┆ --- ┆ --- │
+    #   # │ i64 ┆ f64 ┆ str │
+    #   # ╞═════╪═════╪═════╡
+    #   # │ 1   ┆ 6.0 ┆ a   │
+    #   # │ 3   ┆ 8.0 ┆ c   │
+    #   # └─────┴─────┴─────┘
+    def drop_nans(subset: nil)
+      lazy.drop_nans(subset: subset).collect(_eager: true)
+    end
+
+    # Return a new DataFrame where the null values are dropped.
     #
     # The original order of the remaining rows is preserved.
     #

--- a/lib/polars/lazy_frame.rb
+++ b/lib/polars/lazy_frame.rb
@@ -3307,7 +3307,63 @@ module Polars
       _from_rbldf(_ldf.unique(maintain_order, selector_subset, keep))
     end
 
-    # Drop all rows that contain one or more null values.
+    # Drop all rows that contain one or more NaN values.
+    # The original order of the remaining rows is preserved.
+    #
+    # @param subset [Object]
+    #   Column name(s) for which NaN values are considered; if set to `nil`
+    #   (default), use all columns (note that only floating-point columns
+    #   can contain NaNs).
+    #
+    # @return [LazyFrame]
+    #
+    # @example
+    #   df = Polars::DataFrame.new(
+    #     {
+    #       "foo" => [1, 2, 3],
+    #       "bar" => [6, Float::NAN, 8],
+    #       "ham" => ["a", "b", "c"]
+    #     }
+    #   )
+    #   df.lazy.drop_nans.collect
+    #   # =>
+    #   # shape: (2, 3)
+    #   # ┌─────┬─────┬─────┐
+    #   # │ foo ┆ bar ┆ ham │
+    #   # │ --- ┆ --- ┆ --- │
+    #   # │ i64 ┆ f64 ┆ str │
+    #   # ╞═════╪═════╪═════╡
+    #   # │ 1   ┆ 6.0 ┆ a   │
+    #   # │ 3   ┆ 8.0 ┆ c   │
+    #   # └─────┴─────┴─────┘
+    # @example
+    #   df = Polars::DataFrame.new(
+    #     {
+    #       "foo" => [1, 2, Float::NAN],
+    #       "bar" => [6, Float::NAN, 8],
+    #       "ham" => ["a", "b", "c"]
+    #     }
+    #   )
+    #   df.lazy.drop_nans(subset: "bar").collect
+    #   # =>
+    #   # shape: (2, 3)
+    #   # ┌─────┬─────┬─────┐
+    #   # │ foo ┆ bar ┆ ham │
+    #   # │ --- ┆ --- ┆ --- │
+    #   # │ f64 ┆ f64 ┆ str │
+    #   # ╞═════╪═════╪═════╡
+    #   # │ 1.0 ┆ 6.0 ┆ a   │
+    #   # │ NaN ┆ 8.0 ┆ c   │
+    #   # └─────┴─────┴─────┘
+    def drop_nans(subset: nil)
+      selector_subset = nil
+      if !subset.nil?
+        selector_subset = Utils.parse_list_into_selector(subset)._rbselector
+      end
+      _from_rbldf(_ldf.drop_nans(selector_subset))
+    end
+
+    # Drop rows with null values from this LazyFrame.
     #
     # The original order of the remaining rows is preserved.
     #

--- a/lib/polars/lazy_frame.rb
+++ b/lib/polars/lazy_frame.rb
@@ -3308,6 +3308,7 @@ module Polars
     end
 
     # Drop all rows that contain one or more NaN values.
+    #
     # The original order of the remaining rows is preserved.
     #
     # @param subset [Object]
@@ -3318,43 +3319,35 @@ module Polars
     # @return [LazyFrame]
     #
     # @example
-    #   df = Polars::DataFrame.new(
+    #   lf = Polars::LazyFrame.new(
     #     {
-    #       "foo" => [1, 2, 3],
-    #       "bar" => [6, Float::NAN, 8],
-    #       "ham" => ["a", "b", "c"]
+    #       "foo" => [-20.5, Float::NAN, 80.0],
+    #       "bar" => [Float::NAN, 110.0, 25.5],
+    #       "ham" => ["xxx", "yyy", nil],
     #     }
     #   )
-    #   df.lazy.drop_nans.collect
+    #   lf.drop_nans.collect
     #   # =>
-    #   # shape: (2, 3)
-    #   # ┌─────┬─────┬─────┐
-    #   # │ foo ┆ bar ┆ ham │
-    #   # │ --- ┆ --- ┆ --- │
-    #   # │ i64 ┆ f64 ┆ str │
-    #   # ╞═════╪═════╪═════╡
-    #   # │ 1   ┆ 6.0 ┆ a   │
-    #   # │ 3   ┆ 8.0 ┆ c   │
-    #   # └─────┴─────┴─────┘
+    #   # shape: (1, 3)
+    #   # ┌──────┬──────┬──────┐
+    #   # │ foo  ┆ bar  ┆ ham  │
+    #   # │ ---  ┆ ---  ┆ ---  │
+    #   # │ f64  ┆ f64  ┆ str  │
+    #   # ╞══════╪══════╪══════╡
+    #   # │ 80.0 ┆ 25.5 ┆ null │
+    #   # └──────┴──────┴──────┘
     # @example
-    #   df = Polars::DataFrame.new(
-    #     {
-    #       "foo" => [1, 2, Float::NAN],
-    #       "bar" => [6, Float::NAN, 8],
-    #       "ham" => ["a", "b", "c"]
-    #     }
-    #   )
-    #   df.lazy.drop_nans(subset: "bar").collect
+    #   lf.drop_nans(subset: ["bar"]).collect
     #   # =>
     #   # shape: (2, 3)
-    #   # ┌─────┬─────┬─────┐
-    #   # │ foo ┆ bar ┆ ham │
-    #   # │ --- ┆ --- ┆ --- │
-    #   # │ f64 ┆ f64 ┆ str │
-    #   # ╞═════╪═════╪═════╡
-    #   # │ 1.0 ┆ 6.0 ┆ a   │
-    #   # │ NaN ┆ 8.0 ┆ c   │
-    #   # └─────┴─────┴─────┘
+    #   # ┌──────┬───────┬──────┐
+    #   # │ foo  ┆ bar   ┆ ham  │
+    #   # │ ---  ┆ ---   ┆ ---  │
+    #   # │ f64  ┆ f64   ┆ str  │
+    #   # ╞══════╪═══════╪══════╡
+    #   # │ NaN  ┆ 110.0 ┆ yyy  │
+    #   # │ 80.0 ┆ 25.5  ┆ null │
+    #   # └──────┴───────┴──────┘
     def drop_nans(subset: nil)
       selector_subset = nil
       if !subset.nil?
@@ -3363,7 +3356,7 @@ module Polars
       _from_rbldf(_ldf.drop_nans(selector_subset))
     end
 
-    # Drop rows with null values from this LazyFrame.
+    # Drop all rows that contain one or more null values.
     #
     # The original order of the remaining rows is preserved.
     #


### PR DESCRIPTION
While investigating #117 I found that the `#drop_nans` method was missing.
It's implementation is basically identical as `#drop_nulls`, which made this an easy addition.