### PR TITLE
Fixed sink operations defaulting to in-memory engine

### DIFF
--- a/lib/polars/lazy_frame.rb
+++ b/lib/polars/lazy_frame.rb
@@ -4844,7 +4844,7 @@ module Polars
 
     def _select_engine(engine, path = nil)
       engine = Plr.get_engine_affinity if engine == "auto"
-      engine == "auto" && !path.is_a?(::String) ? "in-memory" : engine
+      engine == "auto" && !path.is_a?(::String) && !path.nil? ? "in-memory" : engine
     end
   end
 end


### PR DESCRIPTION
Changes `_select_engine` to use streaming mode when a file path is provided (sink operations) instead of defaulting to in-memory, which was causing OOM errors with large files.

Addresses #123.