### PR TITLE
fix: Differentiate between empty list an no list for unpivot

### DIFF
--- a/lib/polars/data_frame.rb
+++ b/lib/polars/data_frame.rb
@@ -4593,7 +4593,8 @@ module Polars
     #
     # @param on [Object]
     #   Column(s) or selector(s) to use as values variables; if `on`
-    #   is empty all columns that are not in `index` will be used.
+    #   is empty no columns will be used. If set to `nil` (default)
+    #   all columns that are not in `index` will be used.
     # @param index [Object]
     #   Column(s) or selector(s) to use as identifier variables.
     # @param variable_name [Object]
@@ -4627,7 +4628,7 @@ module Polars
     #   # │ z   ┆ c        ┆ 6     │
     #   # └─────┴──────────┴───────┘
     def unpivot(on = nil, index: nil, variable_name: nil, value_name: nil)
-      on = on.nil? ? [] : Utils._expand_selectors(self, on)
+      on = on.nil? ? nil : Utils._expand_selectors(self, on)
       index = index.nil? ? [] : Utils._expand_selectors(self, index)
 
       _from_rbdf(_df.unpivot(on, index, value_name, variable_name))

--- a/lib/polars/lazy_frame.rb
+++ b/lib/polars/lazy_frame.rb
@@ -4772,7 +4772,8 @@ module Polars
     #
     # @param on [Object]
     #   Column(s) or selector(s) to use as values variables; if `on`
-    #   is empty all columns that are not in `index` will be used.
+    #   is empty no columns will be used. If set to `nil` (default)
+    #   all columns that are not in `index` will be used.
     # @param index [Object]
     #   Column(s) or selector(s) to use as identifier variables.
     # @param variable_name [String]
@@ -4820,12 +4821,12 @@ module Polars
         warn "The `streamable` parameter for `LazyFrame.unpivot` is deprecated"
       end
 
-      selector_on = on.nil? ? Selectors.empty : Utils.parse_list_into_selector(on)
+      selector_on = on.nil? ? nil : Utils.parse_list_into_selector(on)._rbselector
       selector_index = index.nil? ? Selectors.empty : Utils.parse_list_into_selector(index)
 
       _from_rbldf(
         _ldf.unpivot(
-          selector_on._rbselector,
+          selector_on,
           selector_index._rbselector,
           value_name,
           variable_name


### PR DESCRIPTION
I ran into an issue when trying to upgrade from `polars-df` 0.23 to 0.25.1: the unpivot operation couldn't be used to perform a transpose lazily anymore.

```rb
lf = Polars::LazyFrame.new(
  {
    "a" => [3],
    "b" => [1],
    "c" => [2]
  }
)
lf.unpivot.collect
```

is supposed to return
```
# ┌──────────┬───────┐
# │ variable ┆ value │
# │ ---      ┆ ---   │
# │ str      ┆ i64   │
# ╞══════════╪═══════╡
# │ a        ┆ 3     │
# │ b        ┆ 1     │
# │ c        ┆ 2     │
# └──────────┴───────┘
```

but instead returned an empty dataframe.

After digging, it turns out this is because we are missing this patch that was apply upstream in py-polars: https://github.com/pola-rs/polars/pull/25597

So in this PR I am applying the same patch.