### PR TITLE
Build mimalloc v3 to fix unbounded memory growth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,12 +1341,11 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]


### PR DESCRIPTION
Addresses #133.

libmimalloc-sys 0.1.49 builds mimalloc v3 by default, which corrects the cross-thread retention problem.

For context, see microsoft/mimalloc#214.